### PR TITLE
clean up the env file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,6 @@
 name: ioos-qc-front-end
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - ioos_qc
   - streamlit
-prefix: /usr/local/anaconda3/envs/ioos-qc-front-end


### PR DESCRIPTION
This PR removes the hardcoded env directory, to avoid problems when users try to install this, and removes the unnecessary defaults channel. The solver should run much faster with just a single channel space to check.